### PR TITLE
Design/#59 analysis view design

### DIFF
--- a/GumungGagye/GumungGagye/Analysis/AnalysisView.swift
+++ b/GumungGagye/GumungGagye/Analysis/AnalysisView.swift
@@ -112,7 +112,7 @@ struct AnalysisView: View {
                                 }
                                 .foregroundColor(Color("Gray1"))
                                 .modifier(Body2())
-                                .frame(maxWidth: .infinity, minHeight: 58, maxHeight: 58)
+                                .frame(maxWidth: .infinity, minHeight: 44, maxHeight: 44)
                             }
                         }
                     }
@@ -168,7 +168,7 @@ struct AnalysisView: View {
                                 }
                                 .foregroundColor(Color("Gray1"))
                                 .modifier(Body2())
-                                .frame(maxWidth: .infinity, minHeight: 58, maxHeight: 58)
+                                .frame(maxWidth: .infinity, minHeight: 44, maxHeight: 44)
                             }
                         }
                     }

--- a/GumungGagye/GumungGagye/Analysis/AnalysisView.swift
+++ b/GumungGagye/GumungGagye/Analysis/AnalysisView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct AnalysisView: View {
+    
     var body: some View {
-        
             VStack {
                 // - MARK: - 분석 타이틀 / 월 변경
                 
@@ -20,26 +20,7 @@ struct AnalysisView: View {
                         .modifier(H1Bold())
                     
                     // 월 변경
-                    HStack(spacing: 12.0) {
-                        Button {
-                            // 지난 달로
-                        } label: {
-                            Image(systemName: "chevron.left")
-                                .font(.system(size: 16, weight: .bold))
-                                .foregroundColor(Color("Gray1"))
-                        }
-
-                        Text("7월")
-                            .modifier(H2SemiBold())
-                        
-                        Button {
-                            // 다음 달로
-                        } label: {
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 16, weight: .bold))
-                                .foregroundColor(Color("Gray1"))
-                        }
-                    }
+                    MoveMonth(month: "7월", size: .Small)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, 4)
@@ -94,9 +75,9 @@ struct AnalysisView: View {
                         
                         // Top 3 리스트
                         VStack(spacing: 10.0) {
-                            TopContentView(rank: 1, content: "치킨", money: 5000)
-                            TopContentView(rank: 1, content: "치킨", money: 5000)
-                            TopContentView(rank: 1, content: "치킨", money: 5000)
+                            TopContentView(rank: 1, content: "치킨", money: 32000)
+                            TopContentView(rank: 2, content: "아이스크림", money: 17000)
+                            TopContentView(rank: 3, content: "아이폰 케이스", money: 13300)
                         }
                         .padding(.bottom, 28.0)
                         
@@ -149,9 +130,9 @@ struct AnalysisView: View {
                         
                         // Top 3 List
                         VStack(spacing: 10.0) {
-                            TopContentView(rank: 1, content: "치킨", money: 5000)
-                            TopContentView(rank: 1, content: "치킨", money: 5000)
-                            TopContentView(rank: 1, content: "치킨", money: 5000)
+                            TopContentView(rank: 1, content: "식비", money: 155000)
+                            TopContentView(rank: 2, content: "교통비", money: 100300)
+                            TopContentView(rank: 3, content: "카페", money: 75000)
                         }
                         .padding(.bottom, 28.0)
                         .padding(.top, 24)

--- a/GumungGagye/GumungGagye/Analysis/AnalysisView.swift
+++ b/GumungGagye/GumungGagye/Analysis/AnalysisView.swift
@@ -125,7 +125,7 @@ struct AnalysisView: View {
                         }
                         .padding(.vertical, 36.0)
                         
-                        ChartView(values: [900, 500, 300, 200], names: ["식비", "카페", "교통", "건강"], formatter: {value in String(format: "%.0f원", value)}, colors: [Color("Food"), Color("Cafe"), Color("Alcohol"), Color("Etc")])
+                        ChartView(values: [900, 500, 300, 200], names: ["식비", "카페", "교통", "건강"], colors: [Color("Food"), Color("Cafe"), Color("Alcohol"), Color("Etc")], showDescription: false)
                             .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 200, alignment: .center)
                         
                         // Top 3 List

--- a/GumungGagye/GumungGagye/Analysis/AnalysisView.swift
+++ b/GumungGagye/GumungGagye/Analysis/AnalysisView.swift
@@ -4,7 +4,6 @@
 //
 //  Created by jeongyun on 2023/07/10.
 //
-// - TODO: - 요약 숫자 폰트 변경
 
 import SwiftUI
 
@@ -54,12 +53,17 @@ struct AnalysisView: View {
                     VStack(alignment: .leading) {
                         
                         // 과소비 요약
-                        VStack(alignment: .leading, spacing: 4.0) {
-                            Text("과소비를 8번 하지 않았다면")
-                                .modifier(H2SemiBold())
-                            Text("75,500원을 아꼈을텐데")
-                                .modifier(H2SemiBold())
-                                .foregroundColor(Color("Main"))
+                        // - TODO: - 요약 숫자 폰트 변경
+                        VStack(alignment: .leading, spacing: 12.0) {
+                            Text("과소비 분석")
+                                .modifier(Cap1())
+                            VStack(alignment: .leading, spacing: 4.0) {
+                                Text("과소비를 8번 하지 않았다면")
+                                    .modifier(H2SemiBold())
+                                Text("75,500원을 아꼈을텐데")
+                                    .modifier(H2SemiBold())
+                                    .foregroundColor(Color("Main"))
+                            }
                         }
                         .padding(.bottom, 16.0)
                         .padding(.top, 32.0)
@@ -127,11 +131,16 @@ struct AnalysisView: View {
                     VStack(alignment: .leading) {
                         
                         // 카테고리 요약
-                        VStack(alignment: .leading) {
-                            Text("식비에서 200,000원을 사용하여")
-                                .modifier(H2SemiBold())
-                            Text("돈을 가장 많이 썼어요")
-                                .modifier(H2SemiBold())
+                        VStack(alignment: .leading, spacing: 12.0) {
+                        Text("전체소비 분석")
+                            .modifier(Cap1())
+                            
+                            VStack(alignment: .leading, spacing: 4.0) {
+                                Text("식비에서 200,000원을 사용하여")
+                                    .modifier(H2SemiBold())
+                                Text("돈을 가장 많이 썼어요")
+                                    .modifier(H2SemiBold())
+                            }
                         }
                         .padding(.vertical, 36.0)
                         

--- a/GumungGagye/GumungGagye/Analysis/CategoryHistoryView.swift
+++ b/GumungGagye/GumungGagye/Analysis/CategoryHistoryView.swift
@@ -45,9 +45,11 @@ struct CategoryHistoryView: View {
                 .padding(.top, 48.0)
                 
                 // - MARK: - 카테고리 내역 리스트
-                Text("(아마)리나가 만든 내역뷰...")
-                    .frame(maxWidth: .infinity, minHeight: 80, maxHeight: 80)
-                    .background(Color("Gray3"))
+                VStack(spacing: 52.0) {
+                    ForEach(1..<10) {_ in
+                        DateBreakdown()
+                    }
+                }
             }
             .padding(.horizontal, 20.0)
         }

--- a/GumungGagye/GumungGagye/Analysis/ChartsView.swift
+++ b/GumungGagye/GumungGagye/Analysis/ChartsView.swift
@@ -8,43 +8,44 @@
 import SwiftUI
 
 public struct ChartView: View {
-    public let values: [Double]
+    public let values: [Int]
     public let names: [String]
-    public let formatter: (Double) -> String
     public let colors: [Color]
-
+    
+    public let showDescription : Bool
+    
     public var widthFraction: CGFloat
     public var innerRadiusFraction: CGFloat
-
+    
     @State private var activeIndex: Int = 0
-
+    
     var slices: [PieSliceData] {
         let sum = values.reduce(0, +)
         var endDeg: Double = 0
         var tempSlices: [PieSliceData] = []
-
+        
         for (i, value) in values.enumerated() {
-            let degrees: Double = value * 360 / sum
-            tempSlices.append(PieSliceData(startAngle: Angle(degrees: endDeg), endAngle: Angle(degrees: endDeg + degrees),categoryText: names[i] ,percentText: String(format: "%.0f%%", value * 100 / sum), color: self.colors[i]))
+            let degrees: Double = Double(value) * 360 / Double(sum)
+            tempSlices.append(PieSliceData(startAngle: Angle(degrees: endDeg), endAngle: Angle(degrees: endDeg + degrees),categoryText: names[i] ,percentText: String(format: "%.0f%%", Double(value) * 100 / Double(sum)), color: self.colors[i]))
             endDeg += degrees
         }
         return tempSlices
     }
-
-    public init(values:[Double], names: [String], formatter: @escaping (Double) -> String, colors: [Color], widthFraction: CGFloat = 0.75, innerRadiusFraction: CGFloat = 0.50){
+    
+    public init(values:[Int], names: [String], colors: [Color], showDescription: Bool, widthFraction: CGFloat = 0.75, innerRadiusFraction: CGFloat = 0.50){
         self.values = values
         self.names = names
-        self.formatter = formatter
-
         self.colors = colors
+        self.showDescription = showDescription
         self.widthFraction = widthFraction
         self.innerRadiusFraction = innerRadiusFraction
     }
-
+    
     public var body: some View {
-        GeometryReader { geometry in
-//            VStack{
+        VStack(spacing: 60.0) {
+            GeometryReader { geometry in
                 ZStack{
+                    // 차트 조각 모음
                     ForEach(0..<self.values.count){ i in
                         PieSliceView(pieSliceData: self.slices[i], isShowingTag: self.activeIndex == i ? true : false)
                             .scaleEffect(self.activeIndex == i ? 1.1 : 1)
@@ -56,54 +57,33 @@ public struct ChartView: View {
                                 else{
                                     self.activeIndex = -1
                                 }
-                                    
                             }
                     }
                     .frame(maxWidth: .infinity, minHeight: 180, maxHeight: 180)
-                    
                     // 차트 내부 공간
                     Circle()
                         .fill(Color("background"))
                         .frame(width: 80, height: 80)
-                    
-                    // 차트 내부 텍스트
-//                    VStack {
-//                        Text(self.activeIndex == -1 ? "총" : names[self.activeIndex])
-//                            .modifier(Body2())
-//                            .foregroundColor(Color.gray)
-//                        Text(self.formatter(self.activeIndex == -1 ? values.reduce(0, +) : values[self.activeIndex]))
-//                            .modifier(Body1Bold())
-//                    }
-
                 }
-//                PieChartRows(colors: self.colors, names: self.names, values: self.values.map { self.formatter($0) }, percents: self.values.map { String(format: "%.0f%%", $0 * 100 / self.values.reduce(0, +)) })
-//            }
-            .foregroundColor(Color.black)
-        }
-    }
-}
+                .foregroundColor(Color.black)
+            }
 
-struct PieChartRows: View {
-    var colors: [Color]
-    var names: [String]
-    var values: [String]
-    var percents: [String]
-
-    var body: some View {
-        VStack{
-            ForEach(0..<self.values.count){ i in
+            
+            // 선택된 항목 얼마인지 보여주는 text (showDescription = true일 경우)
+            if showDescription == true {
                 HStack {
-                    RoundedRectangle(cornerRadius: 5.0)
-                        .fill(self.colors[i])
-                        .frame(width: 20, height: 20)
-                    Text(self.names[i])
+                    Text(self.activeIndex == -1 ? "총" : names[self.activeIndex])
+                        .foregroundColor(Color("Black"))
+                        .modifier(Body1Bold())
                     Spacer()
-                    VStack(alignment: .trailing) {
-                        Text(self.values[i])
-                        Text(self.percents[i])
-                            .foregroundColor(Color.gray)
-                    }
+                    Text(self.activeIndex == -1 ? "\(values.reduce(0, +))원" : "\(values[self.activeIndex])원")
+                        .foregroundColor(Color("Black"))
+                        .modifier(Body1Bold())
                 }
+                .frame(maxWidth: .infinity, minHeight: 46, maxHeight: 46)
+                .padding(.horizontal, 16.0)
+                .background(Color("Gray4"))
+                .cornerRadius(12)
             }
         }
     }
@@ -111,7 +91,7 @@ struct PieChartRows: View {
 
 struct PieChartView_Previews: PreviewProvider {
     static var previews: some View {
-        ChartView(values: [900, 500, 300, 400], names: ["식비", "카페", "교통", "건강"], formatter: {value in String(format: "%.0f원", value)}, colors: [Color("Food"), Color("Cafe"), Color("Alcohol"), Color("Etc")])
+        ChartView(values: [90000, 50000, 30000, 4000], names: ["식비", "카페", "교통", "건강"], colors: [Color("Food"), Color("Cafe"), Color("Alcohol"), Color("Etc")], showDescription: false)
     }
 }
 

--- a/GumungGagye/GumungGagye/Analysis/OverpurchasingView.swift
+++ b/GumungGagye/GumungGagye/Analysis/OverpurchasingView.swift
@@ -46,10 +46,6 @@ struct OverpurchasingView: View {
                     }
                     .padding(.top, 48.0)
                     
-                    // - MARK: - 과소비 TOP 카테고리
-                    Text("식비에서 200,000원을 사용하여\n돈을 가장 많이 썼어요")
-                        .foregroundColor(Color("Black"))
-                        .modifier(H2SemiBold())
                     
                     // - MARK: - 과소비 차트
                     ChartView(values: [900, 500, 300, 400], names: ["식비", "카페", "교통", "건강"], formatter: {value in String(format: "%.0f원", value)}, colors: [Color("Food"), Color("Cafe"), Color("Alcohol"), Color("Etc")])
@@ -77,9 +73,11 @@ struct OverpurchasingView: View {
                         .foregroundColor(Color("Black"))
                     .modifier(H2SemiBold())
                     
-                    Text("가계부 뷰에서 만들어주시지 않았을까?")
-                        .frame(maxWidth: .infinity, minHeight: 80, maxHeight: 80)
-                        .background(Color("Gray3"))
+                    VStack(spacing: 52.0) {
+                        ForEach(1..<10) {_ in
+                            DateBreakdown()
+                        }
+                    }
                 }
                 .padding(.horizontal, 20.0)
             }

--- a/GumungGagye/GumungGagye/Analysis/OverpurchasingView.swift
+++ b/GumungGagye/GumungGagye/Analysis/OverpurchasingView.swift
@@ -54,11 +54,22 @@ struct OverpurchasingView: View {
                     // - MARK: - 과소비 차트
                     ChartView(values: [900, 500, 300, 400], names: ["식비", "카페", "교통", "건강"], formatter: {value in String(format: "%.0f원", value)}, colors: [Color("Food"), Color("Cafe"), Color("Alcohol"), Color("Etc")])
                         .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 200, alignment: .center)
+                    
+                    HStack {
+                        Text("식비")
+                            .foregroundColor(Color("Black"))
+                            .modifier(Body1Bold())
+                        Spacer()
+                        Text("200,000원")
+                            .foregroundColor(Color("Black"))
+                            .modifier(Body1Bold())
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 46, maxHeight: 46)
+                    .padding(.horizontal, 16.0)
+                    .background(Color("Gray4"))
+                    .cornerRadius(12)
                 }
                 .padding(.horizontal, 20)
-                
-                // - MARK: - 구분선
-                DividerView()
                 
                 // - MARK: - 내역
                 VStack(alignment: .leading, spacing: 36.0) {

--- a/GumungGagye/GumungGagye/Analysis/OverpurchasingView.swift
+++ b/GumungGagye/GumungGagye/Analysis/OverpurchasingView.swift
@@ -16,7 +16,7 @@ struct OverpurchasingView: View {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading, spacing: 12.0) {
                             VStack(alignment: .leading, spacing: 8.0){
-                                HStack(spacing: 4.0) {
+                                HStack(spacing: 3.0) {
                                     Text("2023년 7월")
                                     Text("과소비")
                                         .foregroundColor(Color("OverPurchasing"))
@@ -40,9 +40,6 @@ struct OverpurchasingView: View {
                         }
                         
                         Spacer()
-                        // 카테고리 아이콘
-                        Circle()
-                            .frame(width: 80, height: 80)
                     }
                     .padding(.top, 48.0)
                     

--- a/GumungGagye/GumungGagye/Analysis/OverpurchasingView.swift
+++ b/GumungGagye/GumungGagye/Analysis/OverpurchasingView.swift
@@ -45,22 +45,8 @@ struct OverpurchasingView: View {
                     
                     
                     // - MARK: - 과소비 차트
-                    ChartView(values: [900, 500, 300, 400], names: ["식비", "카페", "교통", "건강"], formatter: {value in String(format: "%.0f원", value)}, colors: [Color("Food"), Color("Cafe"), Color("Alcohol"), Color("Etc")])
-                        .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 200, alignment: .center)
-                    
-                    HStack {
-                        Text("식비")
-                            .foregroundColor(Color("Black"))
-                            .modifier(Body1Bold())
-                        Spacer()
-                        Text("200,000원")
-                            .foregroundColor(Color("Black"))
-                            .modifier(Body1Bold())
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 46, maxHeight: 46)
-                    .padding(.horizontal, 16.0)
-                    .background(Color("Gray4"))
-                    .cornerRadius(12)
+                    ChartView(values: [900, 500, 300, 400], names: ["식비", "카페", "교통", "건강"], colors: [Color("Food"), Color("Cafe"), Color("Alcohol"), Color("Etc")], showDescription: true)
+                        .frame(maxWidth: .infinity, minHeight: 292, maxHeight: 292, alignment: .center)
                 }
                 .padding(.horizontal, 20)
                 

--- a/GumungGagye/GumungGagye/Analysis/TopContentView.swift
+++ b/GumungGagye/GumungGagye/Analysis/TopContentView.swift
@@ -28,11 +28,9 @@ struct TopContentView: View {
                 .modifier(Body1Bold())
             
             Spacer()
-            HStack(spacing: 0){
-                Text("\(money)")
-                Text("원")
-            }
-                .modifier(Num3())
+            
+            Text("\(money)원")
+            .modifier(Num3())
         }
     }
 }


### PR DESCRIPTION
#### 📮 close #59 

## 📌 작업 주제
- 분석뷰의 디자인 수정 사항을 반영하였습니다.

## 🔥 작업 내용
- 분석뷰 서브 타이틀 추가
- 더보기 버튼 수정
- 내역 컴포넌트 적용
- 과소비 카테고리 아이콘 삭제
- 월 이동 컴포넌트 적용
- 차트에서 선택된 항목의 값을 보여주는 뷰 추가
(ex. 식비 23,500원)


## ETC
- 우하하 다들 파이팅입니다
