### PR TITLE
Feat/#119 budget sum

### DIFF
--- a/GumungGagye/GumungGagye/Budget/BudgetPostView.swift
+++ b/GumungGagye/GumungGagye/Budget/BudgetPostView.swift
@@ -29,12 +29,16 @@ struct BudgetPostView: View {
                         .modifier(Body2())
                     Spacer()
                     
-                    Text("+\(incomeSum)원")
-                        .modifier(Num4())
-                        .foregroundColor(Color("Main"))
+                    if incomeSum != 0 {
+                        Text("+\(incomeSum)원")
+                            .modifier(Num4())
+                            .foregroundColor(Color("Main"))
+                    }
                     
-                    Text("-\(spendSum)원")
-                        .modifier(Num4())
+                    if spendSum != 0 {
+                        Text("-\(spendSum)원")
+                            .modifier(Num4())
+                    }
                 }
                     
                 ForEach(accountIDArray, id: \.self) { accountID in

--- a/GumungGagye/GumungGagye/Budget/BudgetPostView.swift
+++ b/GumungGagye/GumungGagye/Budget/BudgetPostView.swift
@@ -21,6 +21,12 @@ struct BudgetPostView: View {
     @State var incomeSum = 0
     @State var spendSum = 0
     
+    @Binding var incomeAsset: Int
+    @Binding var spendAsset: Int
+    
+    @State var isSpendOnappear = true
+    @State var isIncomeOnappear = true
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             if accountIDArray.count > 0 {
@@ -33,11 +39,23 @@ struct BudgetPostView: View {
                         Text("+\(incomeSum)원")
                             .modifier(Num4())
                             .foregroundColor(Color("Main"))
+                            .onAppear {
+                                if isIncomeOnappear {
+                                    incomeAsset += incomeSum
+                                    isIncomeOnappear = false
+                                }
+                            }
                     }
                     
                     if spendSum != 0 {
                         Text("-\(spendSum)원")
                             .modifier(Num4())
+                            .onAppear {
+                                if isSpendOnappear {
+                                    spendAsset += spendSum
+                                    isSpendOnappear = false
+                                }
+                            }
                     }
                 }
                     

--- a/GumungGagye/GumungGagye/Budget/CurrentAssetView.swift
+++ b/GumungGagye/GumungGagye/Budget/CurrentAssetView.swift
@@ -48,7 +48,7 @@ struct CurrentAssetView: View {
                         .modifier(Body2())
                         .foregroundColor(Color("Gray1"))
                     Spacer()
-                    Text("\(spendBill-incomeBill)원")
+                    Text("\(incomeBill-spendBill)원")
                         .modifier(Num3Bold())
                         .foregroundColor(Color("Main"))
                 }

--- a/GumungGagye/GumungGagye/Budget/MainBudgetView.swift
+++ b/GumungGagye/GumungGagye/Budget/MainBudgetView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct MainBudgetView: View {
     @StateObject var userData = InputUserData.shared
+    
+    @State var incomeAsset = 0
+    @State var spendAsset = 0
 
     let today = Calendar.current.component(.day, from: Date())
     let dateFormatter = DateFormatter()
@@ -24,10 +27,10 @@ struct MainBudgetView: View {
                 VStack(spacing:0) {
                     VStack(spacing: 36) {
                         
-                        TargetBudgetView(spendBill: 100000)
+                        TargetBudgetView(spendBill: spendAsset)
                             .padding(.top, 16)
                         SectionBar()
-                        CurrentAssetView(spendBill: 50000, incomeBill: 1000000)
+                        CurrentAssetView(spendBill: spendAsset, incomeBill: incomeAsset)
                         SectionBar()
                             .padding(.bottom, 26)
                     }
@@ -35,7 +38,7 @@ struct MainBudgetView: View {
                     LazyVStack( alignment: .leading, spacing: 0, pinnedViews: [.sectionHeaders]) {
                         Section(header: Header().padding(.bottom, 35)) {
                             ForEach((1...today).reversed(), id:\.self) { day in
-                                BudgetPostView(year: getYear(day: day), month: getMonth(day: day), date: getDate(day: day), day: getDay(day: day))
+                                BudgetPostView(year: getYear(day: day), month: getMonth(day: day), date: getDate(day: day), day: getDay(day: day), incomeAsset: $incomeAsset, spendAsset: $spendAsset)
                             }
                         }
                         .padding(.horizontal, 20)

--- a/GumungGagye/GumungGagye/Budget/TargetBudgetView.swift
+++ b/GumungGagye/GumungGagye/Budget/TargetBudgetView.swift
@@ -11,28 +11,36 @@ struct TargetBudgetView: View {
     
     public let spendBill: Int
     @StateObject var userData = InputUserData.shared
+    @State private var sumGraphWidth: CGFloat = 0.0
     
     var body: some View {
        
         VStack(alignment: .leading, spacing: 0) {
             
             // 목표 예산 알림
-            Text("이번 달 목표 예산이 \n\(formatNumber(userData.goal-spendBill))원 남았어요!")
+            Text("이번 달 목표 예산이 \n\(formatNumber((userData.goal ?? 0)-spendBill))원 남았어요!")
                 .modifier(H2SemiBold())
                 .padding(.bottom, 16)
             
             VStack(spacing: 8) {
                 // 목표 예산 진행바
-                ZStack(alignment: .leading) {
-                    Rectangle()
-                        .frame(width: 335, height: 24)
-                        .cornerRadius(9)
-                        .foregroundColor(Color("Light30"))
-                    Rectangle()
-                        .frame(width: 75, height: 24)
-                        .cornerRadius(9)
-                        .foregroundColor(Color("Main"))
-                }
+                GeometryReader { geometry in
+                    ZStack(alignment: .leading) {
+                        Rectangle()
+                            .frame(maxWidth: .infinity, minHeight: 24, maxHeight: 24)
+                            .cornerRadius(9)
+                            .foregroundColor(Color("Light30"))
+                        Rectangle()
+                            .frame(width: sumGraphWidth, height: 24)
+                            .cornerRadius(9)
+                            .foregroundColor(Color("Main"))
+                    }
+                    .onAppear {
+                        withAnimation(.easeInOut(duration: 1.0)) {
+                            sumGraphWidth = Int(spendBill) > Int(userData.goal ?? 0) ? (geometry.size.width) : CGFloat(Double(spendBill)/Double(userData.goal ?? 09)) * (geometry.size.width)
+                        }
+                    }
+                }.frame(height: 24)
                 
                 
                 HStack {

--- a/GumungGagye/GumungGagye/Budget/TargetBudgetView.swift
+++ b/GumungGagye/GumungGagye/Budget/TargetBudgetView.swift
@@ -37,7 +37,7 @@ struct TargetBudgetView: View {
                     }
                     .onAppear {
                         withAnimation(.easeInOut(duration: 1.0)) {
-                            sumGraphWidth = Int(spendBill) > Int(userData.goal ?? 0) ? (geometry.size.width) : CGFloat(Double(spendBill)/Double(userData.goal ?? 09)) * (geometry.size.width)
+                            sumGraphWidth = Int(spendBill) > Int(userData.goal ?? 0) ? (geometry.size.width) : CGFloat(Double(spendBill)/Double(userData.goal ?? 0)) * (geometry.size.width)
                         }
                     }
                 }.frame(height: 24)

--- a/GumungGagye/GumungGagye/Budget/TargetBudgetView.swift
+++ b/GumungGagye/GumungGagye/Budget/TargetBudgetView.swift
@@ -17,7 +17,7 @@ struct TargetBudgetView: View {
         VStack(alignment: .leading, spacing: 0) {
             
             // 목표 예산 알림
-            Text("이번 달 목표 예산이 \n\(formatNumber(userData.goal))원 남았어요!")
+            Text("이번 달 목표 예산이 \n\(formatNumber(userData.goal-spendBill))원 남았어요!")
                 .modifier(H2SemiBold())
                 .padding(.bottom, 16)
             

--- a/GumungGagye/GumungGagye/Component/Breakdown.swift
+++ b/GumungGagye/GumungGagye/Component/Breakdown.swift
@@ -38,7 +38,7 @@ struct Breakdown: View {
                 
                 HStack {
                     if spendData.open {
-                        OverPurchaseTag(isOverPurchase: false)
+                        OpenTag(spendOpen: true)
                     }
                     if spendData.overConsume {
                         OverPurchaseTag(isOverPurchase: true)

--- a/GumungGagye/GumungGagye/Component/Breakdown.swift
+++ b/GumungGagye/GumungGagye/Component/Breakdown.swift
@@ -15,6 +15,9 @@ struct Breakdown: View {
     @Binding var size: IconSize
     @Binding var incomeSum: Int
     @Binding var spendSum: Int
+    
+    @State var isSpendOnappear = true
+    @State var isIncomeOnappear = true
 
     // accountData를 전달받을 변수 추가
     var accountDataID: String
@@ -31,7 +34,10 @@ struct Breakdown: View {
                         .modifier(Cap2())
                 }
                 .onAppear {
-                    spendSum += spendData.bill
+                    if isSpendOnappear {
+                        spendSum += spendData.bill
+                        isSpendOnappear = false
+                    }
                 }
                 
                 Spacer()
@@ -55,7 +61,10 @@ struct Breakdown: View {
                         .modifier(Cap2())
                 }
                 .onAppear {
-                    incomeSum += incomeData.bill
+                    if isIncomeOnappear {
+                        incomeSum += incomeData.bill
+                        isIncomeOnappear = false
+                    }
                 }
                 
 


### PR DESCRIPTION
#### 📮 close #119 

## 📌 작업 주제
- 가계부 자산 데이터 연결


## 🔥 작업 내용
- 비공개 태그 과소비 태그로 되어있던 것 수정
- 일일 수입/지출 없을 시 합계 안보이게
- 일일 수입/지출 합계 onAppear마다 증가하는 것 수정
- 자산 내역(지출/수입 합계, 남은 금액) 연결
- 예산 그래프 데이터 적용

## ETC
- 파파이팅..!
